### PR TITLE
fix: 그래프뷰 파일이름이 잘못됨

### DIFF
--- a/frontend/my-svelte-app/src/routes.js
+++ b/frontend/my-svelte-app/src/routes.js
@@ -1,6 +1,6 @@
 import PdfManager from "./routes/Pdfmanager.svelte";
 import Chatbot from "./routes/Chatbot.svelte";
-import GraphView from "./routes/GraphView.svelte";
+import GraphView from "./routes/Graphview.svelte";
 
 export default {
   "/pdfmanager": PdfManager,


### PR DESCRIPTION
MacOS, Windows 에서는 대소문자 구분이 없어서 잘작동하나, Linux 에서 오류가 생김